### PR TITLE
fix: webServer timeout error in playwright tests CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"dev": "concurrently \"npm run dev:only\" \"npm run tailwind:watch\"",
 		"build": "npm run tailwind:build && npm run build:only",
 		"preview": "vite preview",
-		"test": "playwright test",
+		"test": "npx playwright test",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --plugin-search-dir . --check . && eslint .",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,10 +1,10 @@
-import type { PlaywrightTestConfig } from '@playwright/test'
+import { defineConfig }  from '@playwright/test'
 
-const config: PlaywrightTestConfig = {
+export default defineConfig({
     reporter: [['json', { outputFile: 'e2eresults.json' }]],
     webServer: {
         command: 'npm run dev',
-        url: 'http://localhost:5173/',
+        port:5173,
         timeout: 240000,
         reuseExistingServer: !process.env.CI,
     },
@@ -12,6 +12,4 @@ const config: PlaywrightTestConfig = {
         baseURL: 'http://localhost:5173/',
     },
     workers: process.env.CI ? 4 : undefined
-}
-
-export default config
+});


### PR DESCRIPTION
# Change log
1. Fixed the webServer timeout error that was causing issue with running tests. There were changes introduced to playwright [1.31.0](https://github.com/microsoft/playwright/releases/tag/v1.31.0) adjusted the configuration to meet the new changes.
2. **External:** Fixes were also made to the npm package [playwright-e2e-coverage-report](https://www.npmjs.com/package/playwright-e2e-coverage-report). Please update the package dependency by upgrading the package, `1.0.20 -> 1.0.21`